### PR TITLE
console.time and console.count to use default label if not provided

### DIFF
--- a/src/Hook/parse/__tests__/Parse.spec.tsx
+++ b/src/Hook/parse/__tests__/Parse.spec.tsx
@@ -8,25 +8,53 @@ it('asserts values', () => {
   )
 })
 
-it('counts numbers', () => {
-  let final
-  _.times(10, () => {
-    final = Parse('count', ['count-10'])
+describe('count', () => {
+  it('counts with label', () => {
+    let final
+
+    _.times(10, () => {
+      final = Parse('count', ['count-10'])
+    })
+
+    expect(final && final.data[0]).toBe('count-10: 10')
   })
 
-  expect(final && final.data[0]).toBe('count-10: 10')
+  it('counts with default label', () => {
+    let final
+
+    _.times(10, () => {
+      final = Parse('count', [])
+    })
+
+    expect(final && final.data[0]).toBe('default: 10')
+  })
 })
 
-it('profiles time', () => {
-  Parse('time', ['timer-test'])
+describe('time', () => {
+  it('profile time with label', () => {
+    Parse('time', ['timer-test'])
 
-  setTimeout(() => {
-    const result = Parse('timeEnd', ['timer-test'], 'timer-result')
-    expect(result && +result.data[0].replace(/[^0-9]/g, '') > 100).toBeTruthy()
-  }, 100)
+    setTimeout(() => {
+      const result = Parse('timeEnd', ['timer-test'], 'timer-result')
+      expect(
+        result && +result.data[0].replace(/[^0-9]/g, '') > 100
+      ).toBeTruthy()
+    }, 100)
+  })
 
-  const failure = Parse('timeEnd', ['nonExistant'], 'timer-fail')
-  expect(failure).toMatchSnapshot('non existant timer')
+  it('non existent label', () => {
+    Parse('time', ['timer-test'])
+
+    const failure = Parse('timeEnd', ['nonExistent'], 'timer-fail')
+    expect(failure).toMatchSnapshot('non existent timer')
+  })
+
+  it('profile time with default label', () => {
+    Parse('time', [])
+
+    const result = Parse('timeEnd', [], 'timer-result')
+    expect(result && result.data[0].match(/^default: \d+\.\d+ms$/)).toBeTruthy()
+  })
 })
 
 it('records errors', () => {

--- a/src/Hook/parse/__tests__/__snapshots__/Parse.spec.tsx.snap
+++ b/src/Hook/parse/__tests__/__snapshots__/Parse.spec.tsx.snap
@@ -11,10 +11,10 @@ Object {
 }
 `;
 
-exports[`profiles time: non existant timer 1`] = `
+exports[`time non existent label: non existent timer 1`] = `
 Object {
   "data": Array [
-    "Timer 'nonExistant' does not exist",
+    "Timer 'nonExistent' does not exist",
   ],
   "id": "timer-fail",
   "method": "warn",

--- a/src/Hook/parse/index.ts
+++ b/src/Hook/parse/index.ts
@@ -29,7 +29,7 @@ function Parse(
     }
 
     case 'count': {
-      const label = typeof data[0] === 'string' ? data[0] : null
+      const label = typeof data[0] === 'string' ? data[0] : 'default'
       if (!label) return false
 
       return {
@@ -40,7 +40,7 @@ function Parse(
 
     case 'time':
     case 'timeEnd': {
-      const label = typeof data[0] === 'string' ? data[0] : null
+      const label = typeof data[0] === 'string' ? data[0] : 'default'
       if (!label) return false
 
       if (method === 'time') {
@@ -55,7 +55,7 @@ function Parse(
     }
 
     case 'assert': {
-      const valid = data.length !== 0 ? true : false
+      const valid = data.length !== 0
 
       if (valid) {
         const assertion = Assert.test(data[0], ...data.slice(1))
@@ -71,7 +71,7 @@ function Parse(
     }
 
     case 'error': {
-      const errors = data.map((error) => {
+      const errors = data.map(error => {
         try {
           return error.stack || error
         } catch (e) {


### PR DESCRIPTION
All browser use label "default" if no label is specified in `time/timeEnd` and `counter` methods:

```
console.time()
// ...
console.timeEnd()
```

Above will result into something like this: `default: 1674.142333984375ms`
