### PR TITLE
Fix word break for long Strings

### DIFF
--- a/src/Component/react-inspector/elements.tsx
+++ b/src/Component/react-inspector/elements.tsx
@@ -10,6 +10,7 @@ interface Props {
  */
 export const Root = styled('div')({
   display: 'inline-block',
+  wordBreak: 'break-all',
   '&::after': {
     content: `' '`,
     display: 'inline-block'


### PR DESCRIPTION
### Current behaviour with long strings

```
console.log(document.querySelector('img'))
```
![console-feed-issue](https://user-images.githubusercontent.com/784056/46634432-38c4a100-cb51-11e8-8306-2fc3f0a96612.gif)


```
console.log(document.querySelector('img').src)
```
![console-feed-issue-2](https://user-images.githubusercontent.com/784056/46634438-3bbf9180-cb51-11e8-97f7-fda00e22e8c5.gif)

### New one

![console-feed-issue-3](https://user-images.githubusercontent.com/784056/46634522-70cbe400-cb51-11e8-988a-9c60f18fdf94.gif)

